### PR TITLE
Make MenuServiceProvider loading as deferred

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -192,11 +192,13 @@ class MenuItem implements ArrayableContract
     /**
      * Add new divider.
      *
+     * @param int $order
+     *
      * @return self
      */
-    public function addDivider()
+    public function addDivider($order = null)
     {
-        $this->childs[] = static::make(array('name' => 'divider'));
+        $this->childs[] = static::make(array('name' => 'divider', 'order' => $order));
 
         return $this;
     }

--- a/MenusServiceProvider.php
+++ b/MenusServiceProvider.php
@@ -12,7 +12,7 @@ class MenusServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = false;
+    protected $defer = true;
 
     /**
      * Bootstrap the application events.


### PR DESCRIPTION
MenuServiceProvider loading should be changed to $defer = true so that we would be able to do conditional menu creation in app/Support/menus.php file. 

```php
Menu::create('navbar', function($menu)
{  
    if (Auth::check()) {
        $menu->add([
            'route' => ['logout', []],
            'title' => t('menu.logout'),
            'attributes' => []
        ]);
    } else {
        $menu->add([
            'route' => ['login', []],
            'title' => t('menu.login'),
            'attributes' => []
        ]);
    }
});
```

If loading is not deferred then each time we do Auth::check() in app/Support/menus.php file we will get false.

Also added $order parameter for addDivider method in MenuItem class so that when creating divider for sub menu it would be possible to set order parameter
