### PR TITLE
Resolvable menu item properties.

### DIFF
--- a/Menu.php
+++ b/Menu.php
@@ -111,7 +111,7 @@ class Menu implements Countable
      */
     public function get($name, $presenter = null, $bindings = [])
     {
-        return $this->has($name) ? 
+        return $this->has($name) ?
             $this->menus[$name]->setBindings($bindings)->render($presenter) : null;
     }
 

--- a/Menu.php
+++ b/Menu.php
@@ -109,7 +109,7 @@ class Menu implements Countable
      *
      * @return string|null
      */
-    public function get($name, $presenter = null, $bindings = [])
+    public function get($name, $presenter = null, $bindings = array())
     {
         return $this->has($name) ?
             $this->menus[$name]->setBindings($bindings)->render($presenter) : null;
@@ -123,7 +123,7 @@ class Menu implements Countable
      *
      * @return string
      */
-    public function render($name, $presenter = null, $bindings = [])
+    public function render($name, $presenter = null, $bindings = array())
     {
         return $this->get($name, $presenter, $bindings);
     }

--- a/Menu.php
+++ b/Menu.php
@@ -109,9 +109,10 @@ class Menu implements Countable
      *
      * @return string|null
      */
-    public function get($name, $presenter = null)
+    public function get($name, $presenter = null, $bindings = [])
     {
-        return $this->has($name) ? $this->menus[$name]->render($presenter) : null;
+        return $this->has($name) ? 
+            $this->menus[$name]->setBindings($bindings)->render($presenter) : null;
     }
 
     /**
@@ -122,9 +123,9 @@ class Menu implements Countable
      *
      * @return string
      */
-    public function render($name, $presenter = null)
+    public function render($name, $presenter = null, $bindings = [])
     {
-        return $this->get($name, $presenter);
+        return $this->get($name, $presenter, $bindings);
     }
 
     /**

--- a/MenuBuilder.php
+++ b/MenuBuilder.php
@@ -66,7 +66,7 @@ class MenuBuilder implements Countable
 
     /**
      * Resolved item binding map.
-     * 
+     *
      * @var array
      */
     protected $bindings = [];
@@ -260,7 +260,7 @@ class MenuBuilder implements Countable
 
     /**
      * Set the resolved item bindings
-     * 
+     *
      * @param array $arr
      */
     public function setBindings(array $bindings)
@@ -271,7 +271,7 @@ class MenuBuilder implements Countable
 
     /**
      * Resolves a key from the bindings array.
-     * 
+     *
      * @param  string|array $key
      * @return mixed
      */
@@ -290,12 +290,12 @@ class MenuBuilder implements Countable
                 }
             }
         }
-        return $key;   
+        return $key;
     }
 
     /**
      * Resolves an array of menu items properties.
-     * 
+     *
      * @param  array  &$items
      * @return void
      */

--- a/MenuBuilder.php
+++ b/MenuBuilder.php
@@ -69,7 +69,7 @@ class MenuBuilder implements Countable
      *
      * @var array
      */
-    protected $bindings = [];
+    protected $bindings = array();
 
     /**
      * Constructor.
@@ -282,7 +282,7 @@ class MenuBuilder implements Countable
                 $key[$k] = $this->resolve($v);
             }
         } elseif (is_string($key)) {
-            $matches = [];
+            $matches = array();
             preg_match_all('/{[\s]*?([^\s]+)[\s]*?}/i', $key, $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {
                 if (array_key_exists($match[1], $this->bindings)) {
@@ -305,7 +305,7 @@ class MenuBuilder implements Countable
             return $this->resolve($property) ?: $property;
         };
 
-        for ($i = 0; $i < count($items); $i ++) {
+        for ($i = 0; $i < count($items); $i++) {
             $items[$i]->fill(array_map($resolver, $items[$i]->getProperties()));
         }
     }

--- a/MenuBuilder.php
+++ b/MenuBuilder.php
@@ -483,6 +483,8 @@ class MenuBuilder implements Countable
      */
     public function render($presenter = null)
     {
+        $this->resolveItems($this->items);
+
         if (!is_null($this->view)) {
             return $this->renderView($presenter);
         }
@@ -505,8 +507,6 @@ class MenuBuilder implements Countable
      */
     public function renderView($presenter = null)
     {
-        $this->resolveItems($this->items);
-
         return $this->views->make($presenter ?: $this->view, [
             'items' => $this->getOrderedItems(),
         ]);
@@ -589,8 +589,6 @@ class MenuBuilder implements Countable
      */
     protected function renderMenu()
     {
-        $this->resolveItems($this->items);
-
         $presenter = $this->getPresenter();
         $menu = $presenter->getOpenTagWrapper();
 

--- a/MenuBuilder.php
+++ b/MenuBuilder.php
@@ -65,6 +65,13 @@ class MenuBuilder implements Countable
     protected $ordering = false;
 
     /**
+     * Resolved item binding map.
+     * 
+     * @var array
+     */
+    protected $bindings = [];
+
+    /**
      * Constructor.
      *
      * @param string $menu
@@ -249,6 +256,58 @@ class MenuBuilder implements Countable
     public function setPresenterFromStyle($name)
     {
         $this->setPresenter($this->getStyle($name));
+    }
+
+    /**
+     * Set the resolved item bindings
+     * 
+     * @param array $arr
+     */
+    public function setBindings(array $bindings)
+    {
+        $this->bindings = $bindings;
+        return $this;
+    }
+
+    /**
+     * Resolves a key from the bindings array.
+     * 
+     * @param  string|array $key
+     * @return mixed
+     */
+    public function resolve($key)
+    {
+        if (is_array($key)) {
+            foreach ($key as $k => $v) {
+                $key[$k] = $this->resolve($v);
+            }
+        } elseif (is_string($key)) {
+            $matches = [];
+            preg_match_all('/{[\s]*?([^\s]+)[\s]*?}/i', $key, $matches, PREG_SET_ORDER);
+            foreach ($matches as $match) {
+                if (array_key_exists($match[1], $this->bindings)) {
+                    $key = preg_replace('/' . $match[0] . '/', $this->bindings[$match[1]], $key, 1);
+                }
+            }
+        }
+        return $key;   
+    }
+
+    /**
+     * Resolves an array of menu items properties.
+     * 
+     * @param  array  &$items
+     * @return void
+     */
+    protected function resolveItems(array &$items)
+    {
+        $resolver = function ($property) {
+            return $this->resolve($property) ?: $property;
+        };
+
+        for ($i = 0; $i < count($items); $i ++) {
+            $items[$i]->fill(array_map($resolver, $items[$i]->getProperties()));
+        }
     }
 
     /**
@@ -446,6 +505,8 @@ class MenuBuilder implements Countable
      */
     public function renderView($presenter = null)
     {
+        $this->resolveItems($this->items);
+
         return $this->views->make($presenter ?: $this->view, [
             'items' => $this->getOrderedItems(),
         ]);
@@ -528,6 +589,8 @@ class MenuBuilder implements Countable
      */
     protected function renderMenu()
     {
+        $this->resolveItems($this->items);
+
         $presenter = $this->getPresenter();
         $menu = $presenter->getOpenTagWrapper();
 


### PR DESCRIPTION
Added the ability to resolve menu item properties at render time. Menus can now be used as templates by specifying a place holder for a property value  `{place.holder}` when creating the menu definition and
specifying an array of bindings when calling `Menu::render`. 

Quick example:

    Menu::create('menu-template', function($menu)
    {
        $menu->url('{item.url}', 'Menu item {item.id}');
    });

    Menu::render('menu-template', null, ['item.url' => 'http://lmgtfy.com/?q=awsome', 'item.id' => 1234, ]);