### PR TITLE
getRequest() in MenuItem breaks in Laravel 5.2

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -321,7 +321,7 @@ class MenuItem implements ArrayableContract
      */
     public function getRequest()
     {
-        return ltrim(str_replace(url(), '', $this->getUrl()), '/');
+        return ltrim(str_replace(url('/'), '', $this->getUrl()), '/');
     }
 
     /**


### PR DESCRIPTION
Hotfix when I call `getRequest()`

> Object of class Illuminate\Routing\UrlGenerator could not be converted to string
