### PR TITLE
getActiveStateFromRoute breaks in laravel 5.2

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -533,7 +533,7 @@ class MenuItem implements ArrayableContract
      */
     protected function getActiveStateFromRoute()
     {
-        return Request::is(str_replace(url().'/', '', $this->getUrl()));
+        return Request::is(str_replace(url('/').'/', '', $this->getUrl()));
     }
 
     /**


### PR DESCRIPTION
Fixing error: Object of class Illuminate\Routing\UrlGenerator could not be converted to string
