### PR TITLE
Add support for all versions of Laravel 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/support": "5.2.*",
-    "illuminate/config": "5.2.*",
-    "illuminate/view": "5.2.*",
+    "illuminate/support": "~5.0",
+    "illuminate/config": "~5.0",
+    "illuminate/view": "~5.0",
     "laravelcollective/html": "~5.0"
   },
   "require-dev": {


### PR DESCRIPTION
Currently this package isn't usable on versions of Laravel older than 5.2, which is wrong IMO as there is no reason it can't support every version of Laravel 5.

This fixes the issue and allows composer update to determine which versions of the illuminate packages are suitable for your installation.
