### PR TITLE
Add default value for attributes variable in getAttributes method.

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -353,7 +353,7 @@ class MenuItem implements ArrayableContract
      */
     public function getAttributes()
     {
-        $attributes = $this->attributes;
+        $attributes = $this->attributes ? $this->attributes : [];
 
         array_forget($attributes, ['active', 'icon']);
 


### PR DESCRIPTION
When $this->attributes is null we got 'null given exception' in array_forget function.
