### PR TITLE
fix order() method isn't work

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -558,6 +558,7 @@ class MenuItem implements ArrayableContract
      */
     public function order($order)
     {
+        $this->properties['order'] = $order;
         $this->order = $order;
 
         return $this;


### PR DESCRIPTION
on MenuBuilder render method, MenuItem re filled by properties
so when you call order() in MenuItem, but when you render it on view
the order isn't work
